### PR TITLE
Updating to support running on KitKat (API 19).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.github.claywilkinson.helloargdx"
-        minSdkVersion 24
+        minSdkVersion 19
         targetSdkVersion 27
 
         versionCode 3

--- a/app/src/main/java/com/github/claywilkinson/arcore/gdx/ARCoreGraphics.java
+++ b/app/src/main/java/com/github/claywilkinson/arcore/gdx/ARCoreGraphics.java
@@ -54,7 +54,10 @@ public class ARCoreGraphics extends AndroidGraphics {
   @Override
   public void onSurfaceChanged(GL10 gl, int width, int height) {
     super.onSurfaceChanged(gl, width, height);
-    WindowManager mgr = application.getSystemService(WindowManager.class);
+    WindowManager mgr = null;
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+      mgr = application.getSystemService(WindowManager.class);
+    }
     int rotation = Surface.ROTATION_0;
     if (mgr != null) {
       rotation = mgr.getDefaultDisplay().getRotation();

--- a/app/src/main/java/com/github/claywilkinson/arcore/gdx/util/ARSessionSupport.java
+++ b/app/src/main/java/com/github/claywilkinson/arcore/gdx/util/ARSessionSupport.java
@@ -34,6 +34,7 @@ import com.google.ar.core.Frame;
 import com.google.ar.core.Session;
 import com.google.ar.core.exceptions.UnavailableApkTooOldException;
 import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException;
+import com.google.ar.core.exceptions.UnavailableDeviceNotCompatibleException;
 import com.google.ar.core.exceptions.UnavailableSdkTooOldException;
 
 
@@ -95,6 +96,8 @@ public class ARSessionSupport implements LifecycleObserver {
     ArCoreApk.Availability availability = ArCoreApk.getInstance().checkAvailability(activity);
     Log.d(TAG, "Availability is " + availability);
 
+    try {
+
     if (ArCoreApk.getInstance().requestInstall(activity, mUserRequestedInstall) ==
             ArCoreApk.InstallStatus.INSTALL_REQUESTED) {
       // Ensures next invocation of requestInstall() will either return
@@ -103,7 +106,7 @@ public class ARSessionSupport implements LifecycleObserver {
       return;
     }
 
-    try {
+
 
       session = new Session(activity);
     } catch (UnavailableArcoreNotInstalledException e) {
@@ -117,6 +120,10 @@ public class ARSessionSupport implements LifecycleObserver {
     } catch (UnavailableSdkTooOldException e) {
       message = "Please update this app";
       setStatus(ARStatus.SDKTooOld);
+      exception = e;
+    } catch (UnavailableDeviceNotCompatibleException e) {
+      setStatus(ARStatus.DeviceNotSupported);
+      message = "This device does not support AR";
       exception = e;
     } catch (Exception e) {
       setStatus(ARStatus.UnknownException);
@@ -274,6 +281,7 @@ public class ARSessionSupport implements LifecycleObserver {
     UnknownException,
     NeedCameraPermission,
     Ready,
+    DeviceNotSupported,
     Uninitialized
   }
 }


### PR DESCRIPTION
ARCore does not support KitKat, but now the app can run, and gives a
nice error message.